### PR TITLE
docs: add Evan Wu to team members

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -127,6 +127,10 @@ Our multidisciplinary team includes:
   * 資深後端工程師 / Senior Backend Engineer  
   * 基礎設施工程師 / Infrastructure Engineer
 
+* **Evan Wu** <!-- May. 2026 ~ now -->
+  * 資深 iOS 工程師 / Senior iOS Engineer
+  * 後端工程師 / Backend Engineer
+
 ### 前團隊成員 / Alumni
 
 * **Jojo Chien** (Apr. ~ Sep. 2025)


### PR DESCRIPTION
## Summary

- 在 About 頁面的團隊成員清單末尾新增 Evan Wu
- 職稱：資深 iOS 工程師 / Senior iOS Engineer
- 職稱：後端工程師 / Backend Engineer

## Changes

- `content/about.md`: 在 Holmes Lin 之後、前團隊成員區塊之前加入 Evan Wu 的條目

🤖 Generated with [Claude Code](https://claude.com/claude-code)